### PR TITLE
Fix the path to upload the plugin artifacts

### DIFF
--- a/plugin-ci/build/action.yaml
+++ b/plugin-ci/build/action.yaml
@@ -26,5 +26,5 @@ runs:
       with:
         name: dist
         path: |
-          - "*.tar.gz"
-          - "release-notes.md"
+          - "dist/*.tar.gz"
+          - "dist/release-notes.md"


### PR DESCRIPTION
#### Summary
The path is under `dist/*` and in parallel we removed the non-used action as secrets are not supported for custom actions.


#### Ticket Link
Ticket: https://mattermost.atlassian.net/browse/CLD-4681

