### PR TITLE
Skip setup node if webapp directory doesn't exist

### DIFF
--- a/plugin-ci/setup/action.yaml
+++ b/plugin-ci/setup/action.yaml
@@ -14,10 +14,33 @@ inputs:
       The version to use for golangci-lint
     required: false
 
+  golang-cache-enabled:
+    default: "true"
+    description: |
+      Enable golang caching in CI
+    required: false
+
+  golang-version:
+    default: "1.19"
+    description: |
+      Set the version for Golang
+    required: false
+
 runs:
   using: "composite"
   steps:
+    - name: Check for webapp
+      id: webapp_check
+      shell: bash
+      run: |
+        if [ -d "webapp" ]; then
+          echo "exist=true" >> $GITHUB_OUTPUT
+        else
+          echo "exist=false" >> $GITHUB_OUTPUT
+        fi
+
     - name: Install Node
+      if: steps.webapp_check.outputs.exist == 'true'
       uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516
       with:
         node-version-file: ".nvmrc"
@@ -28,3 +51,9 @@ runs:
       shell: bash
       run: |
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin ${{ inputs.golangci-lint-version }}
+
+    - name: Setup Go
+      uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
+      with:
+        go-version: ${{ inputs.golang-version }}
+        cache: ${{ inputs.golang-cache-enabled }}


### PR DESCRIPTION
#### Summary
Some plugins has no UI so the webapp directory doesn't exist at all. For these cases there's no need to setup node. In parallel we move Golang setup in the re-usable `setup` action.

#### Ticket Link
Ticket: https://mattermost.atlassian.net/browse/CLD-4816
