### PR TITLE
MM-52947 Change retention period of scheduled plugin builds to 5 days

### DIFF
--- a/plugin-ci/build/action.yaml
+++ b/plugin-ci/build/action.yaml
@@ -23,20 +23,10 @@ runs:
         fi
 
     - uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
-      if: ${{ github.event_name != 'schedule' }}
       with:
         name: dist
         path: |
           dist/*.tar.gz
           dist/release-notes.md
         if-no-files-found: error
-
-    - uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
-      if: ${{ github.event_name == 'schedule' }}
-      with:
-        name: dist
-        path: |
-          dist/*.tar.gz
-          dist/release-notes.md
-        if-no-files-found: error
-        retention-days: 5
+        retention-days: ${{ github.event_name == 'schedule' && 5 || 90 }}

--- a/plugin-ci/build/action.yaml
+++ b/plugin-ci/build/action.yaml
@@ -23,9 +23,20 @@ runs:
         fi
 
     - uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
+      if: ${{ github.event_name != 'schedule' }}
       with:
         name: dist
         path: |
           dist/*.tar.gz
           dist/release-notes.md
         if-no-files-found: error
+
+    - uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
+      if: ${{ github.event_name == 'schedule' }}
+      with:
+        name: dist
+        path: |
+          dist/*.tar.gz
+          dist/release-notes.md
+        if-no-files-found: error
+        retention-days: 5


### PR DESCRIPTION
#### Summary

Scheduled jobs running for forked plugin repos have been causing GitHub accounts to reach artifact storage limits on GitHub. More info here https://community.mattermost.com/private-core/pl/6jgduthxaiyepcek7k3iacgpyw

There is an open PR to disable scheduled jobs for forked repositories https://github.com/mattermost/mattermost-plugin-starter-template/pull/180. Though this would need to applied to all plugin repositories.

This PR is a more centralized solution. It makes it so we only store scheduled job artifacts for 5 days, rather than the default of 90 days. This is done regardless if the repository is a Mattermost-owned repo or a forked repo.

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-52947