### PR TITLE
Update go version to 1.21

### DIFF
--- a/plugin-ci/setup/action.yaml
+++ b/plugin-ci/setup/action.yaml
@@ -21,7 +21,7 @@ inputs:
     required: false
 
   golang-version:
-    default: "1.19"
+    default: "1.21"
     description: |
       Set the version for Golang
     required: false


### PR DESCRIPTION
#### Summary
Due to the [backwards compatible changes in go1.21](https://go.dev/blog/compat), this should not break existing plugins, while allowing them to opt-into newer language features (see https://tip.golang.org/blog/toolchain for more details).

#### Ticket Link
None