### PR TITLE
Utilize given TARGET_URL

### DIFF
--- a/delivery/update-commit-status/action.yaml
+++ b/delivery/update-commit-status/action.yaml
@@ -52,7 +52,7 @@ runs:
               context: CONTEXT,
               description: DESCRIPTION,
               state: STATUS,
-              target_url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+              target_url: TARGET_URL
             });
             core.info(`Updated build status with ${STATUS} for commit ${SHA} on ${REPOSITORY_FULL_NAME}`);
           } catch (err) {


### PR DESCRIPTION
#### Summary

Fix: actually use the TARGET_URL set in the action's inputs, when producing the status check.

#### Ticket Link

https://mattermost.atlassian.net/browse/CLD-7198