### PR TITLE
fix: Use ad-1 as display name for Compatibility Matrix Testing instances

### DIFF
--- a/delivery/create-cloud-installation/init.sh
+++ b/delivery/create-cloud-installation/init.sh
@@ -19,7 +19,7 @@ fi
 CMD_ARGS+=("--cluster-installation \"${CLUSTER_INSTALLATION_ID}\"")
 
 CREATE_USER_ARGS=("--command \"user create --local --disable-welcome-email --system-admin --email-verified --email admin@example.com --username ${MM_INIT_USERNAME} --password ${MM_INIT_PASSWORD}\"")
-CREATE_TEAM_ARGS=("--command \"team create --local --name main --display-name DeliveryTeamCMT --email admin@example.com\"")
+CREATE_TEAM_ARGS=("--command \"team create --local --name main --display-name ad-1 --email admin@example.com\"")
 ADD_USER_TO_TEAM_ARGS=("--command \"team users add main admin --local\"")
 
 CREATE_USER_COMMAND="${CMD[@]} ${CMD_ARGS[@]} ${CREATE_USER_ARGS[@]}"


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
Use ad-1 as display name for Compatibility Matrix Testing instances

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
