### PR TITLE
Fix target_url handling for update-commit-status, pt2

### DIFF
--- a/delivery/update-commit-status/action.yaml
+++ b/delivery/update-commit-status/action.yaml
@@ -33,12 +33,12 @@ runs:
         CONTEXT: ${{ inputs.context }}
         DESCRIPTION: ${{ inputs.description }}
         STATUS: ${{ inputs.status }}
+        TARGET_URL: ${{ inputs.target_url }}
       with:
         github-token: ${{ env.GITHUB_TOKEN }}
         script: |
           try {
-            var { REPOSITORY_FULL_NAME, SHA, CONTEXT, DESCRIPTION, STATUS } = process.env;
-            var TARGET_URL = core.getInput('target_url', { required: false });
+            var { REPOSITORY_FULL_NAME, SHA, CONTEXT, DESCRIPTION, STATUS, TARGET_URL } = process.env;
 
             if (TARGET_URL) {}
             else { 


### PR DESCRIPTION
#### Summary

`target_url` kept not working, likely due to the action being included in another action: https://github.com/actions/toolkit/issues/1124
You can check the description in the ticket below, for an example where this became known.

This PR fixes this. I checked this in the following jobs (from [the two commits in this PR](https://github.com/mattermost/mattermost/pull/26852)):
- When not specifying `target_url`: https://github.com/mattermost/mattermost/actions/runs/8804564265/job/24165204880#step:2:2
- When specifying `target_url`: https://github.com/mattermost/mattermost/actions/runs/8804594488/job/24165300797#step:2:2

#### Ticket Link

https://mattermost.atlassian.net/browse/CLD-7395
