### PR TITLE
plugin-ci/test: Stop generating plugin coverage

### DIFF
--- a/plugin-ci/test/action.yaml
+++ b/plugin-ci/test/action.yaml
@@ -9,12 +9,3 @@ runs:
     - name: test-plugin
       shell: bash
       run: make test
-
-    - name: generate-goverage
-      shell: bash
-      run: make coverage
-
-    - name: upload-coverage
-      uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # v3.1.1
-      with:
-        files: server/coverage.txt


### PR DESCRIPTION
#### Summary
See https://community.mattermost.com/core/pl/derzswanf7rm3dqyirz344f9qw, but the pattern of running `make test` and `make coverage` effectively runs `go test` twice, and the resulting code coverage from the second run is getting discarded anyway due to upstream rate limiting:

![CleanShot 2024-05-14 at 09 30 55@2x](https://github.com/mattermost/actions/assets/1023171/1d461e6f-d13b-4bb6-b821-89ae50b185c4)

![CleanShot 2024-05-14 at 09 31 31@2x](https://github.com/mattermost/actions/assets/1023171/7cc4061c-3e0d-4d58-a685-a6d20674b7b1)

![CleanShot 2024-05-14 at 09 45 29@2x](https://github.com/mattermost/actions/assets/1023171/66cea4fc-b3ad-47eb-b7a5-9f779538fce2)


Proposing we just nix this.

#### Ticket Link
None.