### PR TITLE
Add action to create a check run

### DIFF
--- a/delivery/create-check-run/README.md
+++ b/delivery/create-check-run/README.md
@@ -1,0 +1,17 @@
+# create-check-run
+
+This action creates a new check run of the declared commit sha with the desired state
+
+| Input                  | Description                                                                                           |
+| ---------------------- | ----------------------------------------------------------------------------------------------------- |
+| *repository_full_name* | The full name of the repository `<org>/<repo>`                                                        |
+| *commit_sha*           | The originating commit sha of the event                                                               |
+| *name*                 | The name of the check                                                                                 |
+| *summary*              | The summary of the check                                                                              |
+| *title*                | The title of the check                                                                                |
+| *status*               | The status of the status check. Can be one of `queued`, `in_progress` or `completed`                  |
+| *details_url*          | The target url of the status check. By default returns the current running workflow URL               |
+
+
+
+

--- a/delivery/create-check-run/action.yaml.
+++ b/delivery/create-check-run/action.yaml.
@@ -1,0 +1,68 @@
+# Copyright 2022 Mattermost, Inc.
+name: "mattermost/create-check-run"
+description: "An action that creates a check run"
+
+inputs:
+  repository_full_name:
+    description: "The full name of the repository"
+    required: true
+  commit_sha:
+    description: "The sha of the commit to update the status"
+    required: true
+  name:
+    description: "The name of the check"
+    required: true
+  summary:
+    description: "The summary of the check"
+    required: true
+  title:
+    description: "The title of the check"
+    required: true
+  status:
+    description: "The state of the status check"
+    required: true
+  target_url:
+    description: "The target url of the status check"
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: ci/update-commit-status
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # 7.0.1
+      env:
+        REPOSITORY_FULL_NAME: ${{ inputs.repository_full_name }}
+        SHA: ${{ inputs.commit_sha }}
+        NAME: ${{ inputs.name }}
+        SUMMARY: ${{ inputs.summary }}
+        TITLE: ${{ inputs.title }}
+        STATUS: ${{ inputs.status }}
+        TARGET_URL: ${{ inputs.target_url }}
+      with:
+        github-token: ${{ env.GITHUB_TOKEN }}
+        script: |
+          try {
+            var { REPOSITORY_FULL_NAME, SHA, NAME, SUMMARY, TITLE, STATUS, TARGET_URL } = process.env;
+
+            if (TARGET_URL) {}
+            else { 
+              var TARGET_URL = "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}";
+            }
+
+            await github.rest.checks.create({
+              owner: REPOSITORY_FULL_NAME.split("/")[0],
+              repo: REPOSITORY_FULL_NAME.split("/")[1],
+              head_sha: SHA,
+              name: NAME,
+              status: STATUS,
+              output: {
+                summary: SUMMARY,
+                title: TITLE
+              },
+              details_url: TARGET_URL
+            });
+            core.info(`Updated build status with ${STATUS} for commit ${SHA} on ${REPOSITORY_FULL_NAME}`);
+          } catch (err) {
+            core.error(`Failed to update build status with ${STATUS} for commit ${SHA} on ${REPOSITORY_FULL_NAME}`);
+            core.setFailed(`Action failed with error: ${err}`);
+          }


### PR DESCRIPTION
Currently, `update-commit-status` only creates a commit status, not an actual check run.
The shortcoming is that it does not allow us to set the status to "in-progress".
That is why you will see status as pending, but the description will say
"Enterprise tests are running".

To fix this discrepancy, we need to create a check rather than a commit status.
This gives us more control over the status of the check.
More documentation here: https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28#create-a-check-run.

For now, I created a new action so as to not interfere with any existing action
and not break anything in CI. After this, I want to slowly migrate the existing
CI workflows which use commit statuses to this new action.
