### PR TITLE
Add reusable action for Anchore scanning

### DIFF
--- a/delivery/anchore-scan/README.md
+++ b/delivery/anchore-scan/README.md
@@ -13,9 +13,9 @@ jobs:
         with:
           image_name: '<MATTERMOST_IMAGE>'
           dockerfile_path: '<RELATIVE_PATH_TO_DOCKERFILE>'
-          anchorectl_url: ${{ secrets.ANCHORE_URL }}
-          anchorectl_username: ${{ secrets.ANCHORE_USERNAME }}
-          anchorectl_password: ${{ secrets.ANCHORE_PASSWORD }}
+          anchorectl_url: ${{ secrets.ANCHORECTL_URL }}
+          anchorectl_username: ${{ secrets.ANCHORECTL_USERNAME }}
+          anchorectl_password: ${{ secrets.ANCHORECTL_PASSWORD }}
           ts_oauth_client_id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
           ts_oauth_secret: ${{ secrets.TS_OAUTH_SECRET }}
 ```

--- a/delivery/anchore-scan/README.md
+++ b/delivery/anchore-scan/README.md
@@ -1,0 +1,41 @@
+# anchore-scan
+
+This action scans Docker images with Anchore for security vulnerabilities using Tailscale connectivity.
+
+### Usage
+
+```yaml
+jobs:
+  scan:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: mattermost/actions/delivery/anchore-scan@main
+        with:
+          image_name: '<MATTERMOST_IMAGE>'
+          dockerfile_path: '<RELATIVE_PATH_TO_DOCKERFILE>'
+          anchorectl_url: ${{ secrets.ANCHORE_URL }}
+          anchorectl_username: ${{ secrets.ANCHORE_USERNAME }}
+          anchorectl_password: ${{ secrets.ANCHORE_PASSWORD }}
+          ts_oauth_client_id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          ts_oauth_secret: ${{ secrets.TS_OAUTH_SECRET }}
+```
+
+### Inputs
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `image_name` | Docker image name to scan (with tag) | Yes | - |
+| `dockerfile_path` | Path to Dockerfile for context | No | `./Dockerfile` |
+| `show_vulnerabilities` | Whether to retrieve and display vulnerabilities after adding image | No | `true` |
+| `anchorectl_url` | Anchore URL | Yes | - |
+| `anchorectl_username` | Anchore username | Yes | - |
+| `anchorectl_password` | Anchore password | Yes | - |
+| `ts_oauth_client_id` | Tailscale OAuth client ID | Yes | - |
+| `ts_oauth_secret` | Tailscale OAuth secret | Yes | - |
+
+### Outputs
+
+| Output | Description |
+|--------|-------------|
+| `vulnerabilities_file` | Path to vulnerabilities text file |
+| `image_added` | Whether image was successfully added |

--- a/delivery/anchore-scan/action.yaml
+++ b/delivery/anchore-scan/action.yaml
@@ -49,38 +49,49 @@ runs:
 
     - name: Install Anchore CLI
       shell: bash
+      env:
+        ANCHORECTL_VERSION: "5.21.0"
       run: |
-        echo "Installing anchorectl CLI version 5.21.0..."
-        curl -sSfL https://anchorectl-releases.anchore.io/anchorectl/install.sh | sh -s -- -b /usr/local/bin v5.21.0
+        echo "Installing anchorectl CLI version ${ANCHORECTL_VERSION}..."
+        curl -sSfL https://anchorectl-releases.anchore.io/anchorectl/install.sh | sh -s -- -b /usr/local/bin v${ANCHORECTL_VERSION}
         anchorectl version
 
     - name: Configure Anchore
       shell: bash
+      env:
+        ANCHORE_URL: ${{ inputs.anchorectl_url }}
+        ANCHORE_USERNAME: ${{ inputs.anchorectl_username }}
+        ANCHORE_PASSWORD: ${{ inputs.anchorectl_password }}
       run: |
         echo "Configuring Anchore..."
-        echo "ANCHORECTL_URL=${{ inputs.anchorectl_url }}" >> $GITHUB_ENV
-        echo "ANCHORECTL_USERNAME=${{ inputs.anchorectl_username }}" >> $GITHUB_ENV
-        echo "ANCHORECTL_PASSWORD=${{ inputs.anchorectl_password }}" >> $GITHUB_ENV
+        echo "ANCHORECTL_URL=${ANCHORE_URL}" >> $GITHUB_ENV
+        echo "ANCHORECTL_USERNAME=${ANCHORE_USERNAME}" >> $GITHUB_ENV
+        echo "ANCHORECTL_PASSWORD=${ANCHORE_PASSWORD}" >> $GITHUB_ENV
         echo "ANCHORECTL_ACCOUNT=saml" >> $GITHUB_ENV
         # TODO: Remove this line once TLS certificate issue is resolved
         echo "ANCHORECTL_HTTP_TLS_INSECURE=true" >> $GITHUB_ENV
 
     - name: Pull Docker image
       shell: bash
+      env:
+        IMAGE_NAME: ${{ inputs.image_name }}
       run: |
-        echo "Pulling Docker image: ${{ inputs.image_name }}"
-        docker pull ${{ inputs.image_name }}
+        echo "Pulling Docker image: ${IMAGE_NAME}"
+        docker pull "${IMAGE_NAME}"
 
     - name: Add image to Anchore and wait for analysis
       shell: bash
       id: add-image
+      env:
+        IMAGE_NAME: ${{ inputs.image_name }}
+        DOCKERFILE_PATH: ${{ inputs.dockerfile_path }}
       run: |
         echo "Adding image to Anchore for analysis..."
-        echo "Using Dockerfile: ${{ inputs.dockerfile_path }}"
+        echo "Using Dockerfile: ${DOCKERFILE_PATH}"
         echo "Waiting for analysis to complete..."
 
         # Add image with --wait flag to wait for analysis completion
-        if ! anchorectl image add ${{ inputs.image_name }} --dockerfile ${{ inputs.dockerfile_path }} --force  --wait; then
+        if ! anchorectl image add "${IMAGE_NAME}" --dockerfile "${DOCKERFILE_PATH}" --force  --wait; then
           echo "❌ Failed to add image to Anchore or analysis failed"
           exit 1
         fi
@@ -92,16 +103,18 @@ runs:
       shell: bash
       id: scan
       if: ${{ inputs.show_vulnerabilities == 'true' }}
+      env:
+        IMAGE_NAME: ${{ inputs.image_name }}
       run: |
-        echo "🔍 Retrieving vulnerabilities for ${{ inputs.image_name }}..."
+        echo "🔍 Retrieving vulnerabilities for ${IMAGE_NAME}..."
 
         # Create safe filename from image name
-        safe_name=$(echo "${{ inputs.image_name }}" | sed 's/[^a-zA-Z0-9._-]/_/g')
+        safe_name=$(echo "${IMAGE_NAME}" | sed 's/[^a-zA-Z0-9._-]/_/g')
         output_file="vulnerabilities_${safe_name}.txt"
 
         # Get vulnerabilities with error handling
-        if ! anchorectl image vulnerabilities ${{ inputs.image_name }} > "$output_file" 2>&1; then
-          echo "❌ Failed to retrieve vulnerabilities for ${{ inputs.image_name }}"
+        if ! anchorectl image vulnerabilities "${IMAGE_NAME}" > "$output_file" 2>&1; then
+          echo "❌ Failed to retrieve vulnerabilities for ${IMAGE_NAME}"
           echo "📄 Error details:"
           cat "$output_file" 2>/dev/null || echo "No error details available"
           exit 1

--- a/delivery/anchore-scan/action.yaml
+++ b/delivery/anchore-scan/action.yaml
@@ -1,0 +1,108 @@
+name: 'Anchore Container Vulnerability Scan'
+description: 'Scan Docker images with Anchore for vulnerabilities'
+inputs:
+  image_name:
+    description: 'Docker image name to scan (with tag)'
+    required: true
+  dockerfile_path:
+    description: 'Path to Dockerfile for context'
+    required: false
+    default: './Dockerfile'
+  show_vulnerabilities:
+    description: 'Whether to retrieve and display vulnerabilities after adding image'
+    required: false
+    default: 'true'
+  anchorectl_url:
+    description: 'Anchore URL'
+    required: true
+  anchorectl_username:
+    description: 'Anchore username'
+    required: true
+  anchorectl_password:
+    description: 'Anchore password'
+    required: true
+  ts_oauth_client_id:
+    description: 'Tailscale OAuth client ID'
+    required: true
+  ts_oauth_secret:
+    description: 'Tailscale OAuth secret'
+    required: true
+outputs:
+  vulnerabilities_file:
+    description: 'Path to vulnerabilities text file'
+    value: ${{ steps.scan.outputs.vulnerabilities_file }}
+  image_added:
+    description: 'Whether image was successfully added'
+    value: ${{ steps.add-image.outputs.success }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Configure Tailscale
+      uses: tailscale/github-action@8688eb839e58e6b25c1ae96cd99d1c173299b842 # v3
+      with:
+        version: latest
+        oauth-client-id: ${{ inputs.ts_oauth_client_id }}
+        oauth-secret: ${{ inputs.ts_oauth_secret }}
+        tags: tag:anchore-github-actions
+        args: --accept-dns
+
+    - name: Install Anchore CLI
+      shell: bash
+      run: |
+        echo "Installing anchorectl CLI version 5.21.0..."
+        curl -sSfL https://anchorectl-releases.anchore.io/anchorectl/install.sh | sh -s -- -b /usr/local/bin v5.21.0
+        anchorectl version
+
+    - name: Configure Anchore
+      shell: bash
+      run: |
+        echo "Configuring Anchore..."
+        echo "ANCHORE_CLI_URL=${{ inputs.anchorectl_url }}" >> $GITHUB_ENV
+        echo "ANCHORE_CLI_USER=${{ inputs.anchorectl_username }}" >> $GITHUB_ENV
+        echo "ANCHORE_CLI_PASS=${{ inputs.anchorectl_password }}" >> $GITHUB_ENV
+
+    - name: Pull Docker image
+      shell: bash
+      run: |
+        echo "Pulling Docker image: ${{ inputs.image_name }}"
+        docker pull ${{ inputs.image_name }}
+
+    - name: Add image to Anchore and wait for analysis
+      shell: bash
+      id: add-image
+      run: |
+        echo "Adding image to Anchore for analysis..."
+        echo "Using Dockerfile: ${{ inputs.dockerfile_path }}"
+        echo "Waiting for analysis to complete..."
+
+        # Add image with --wait flag to wait for analysis completion
+        if ! anchorectl image add ${{ inputs.image_name }} --dockerfile ${{ inputs.dockerfile_path }} --force  --wait; then
+          echo "❌ Failed to add image to Anchore or analysis failed"
+          exit 1
+        fi
+
+        echo "✅ Image successfully added and analyzed"
+        echo "success=true" >> $GITHUB_OUTPUT
+
+    - name: Retrieve vulnerabilities
+      shell: bash
+      id: scan
+      if: ${{ inputs.show_vulnerabilities == 'true' }}
+      run: |
+        echo "🔍 Retrieving vulnerabilities for ${{ inputs.image_name }}..."
+
+        # Create safe filename from image name
+        safe_name=$(echo "${{ inputs.image_name }}" | sed 's/[^a-zA-Z0-9._-]/_/g')
+        output_file="vulnerabilities_${safe_name}.txt"
+
+        # Get vulnerabilities with error handling
+        if ! anchorectl image vulnerabilities ${{ inputs.image_name }} > "$output_file" 2>&1; then
+          echo "❌ Failed to retrieve vulnerabilities for ${{ inputs.image_name }}"
+          echo "📄 Error details:"
+          cat "$output_file" 2>/dev/null || echo "No error details available"
+          exit 1
+        fi
+
+        echo "✅ Vulnerabilities saved to: $output_file"
+        echo "vulnerabilities_file=$output_file" >> $GITHUB_OUTPUT

--- a/delivery/anchore-scan/action.yaml
+++ b/delivery/anchore-scan/action.yaml
@@ -58,9 +58,12 @@ runs:
       shell: bash
       run: |
         echo "Configuring Anchore..."
-        echo "ANCHORE_CLI_URL=${{ inputs.anchorectl_url }}" >> $GITHUB_ENV
-        echo "ANCHORE_CLI_USER=${{ inputs.anchorectl_username }}" >> $GITHUB_ENV
-        echo "ANCHORE_CLI_PASS=${{ inputs.anchorectl_password }}" >> $GITHUB_ENV
+        echo "ANCHORECTL_URL=${{ inputs.anchorectl_url }}" >> $GITHUB_ENV
+        echo "ANCHORECTL_USERNAME=${{ inputs.anchorectl_username }}" >> $GITHUB_ENV
+        echo "ANCHORECTL_PASSWORD=${{ inputs.anchorectl_password }}" >> $GITHUB_ENV
+        echo "ANCHORECTL_ACCOUNT=saml" >> $GITHUB_ENV
+        # TODO: Remove this line once TLS certificate issue is resolved
+        echo "ANCHORECTL_HTTP_TLS_INSECURE=true" >> $GITHUB_ENV
 
     - name: Pull Docker image
       shell: bash


### PR DESCRIPTION
#### Summary
* Adds a reusable Github Action for Anchore scanning during CD. This action will be reused across different CD workflows for various Mattermost docker artifacts. 

I've tested the action code here, using the same code as a reusable action stored within Enterprise: https://github.com/mattermost/enterprise/actions/runs/18343927617/job/52245897582?pr=1992

#### Ticket Link
https://mattermost.atlassian.net/browse/SEC-8738

