### PR TITLE
add provisioner auth TOKEN

### DIFF
--- a/delivery/create-cloud-installation/action.yaml
+++ b/delivery/create-cloud-installation/action.yaml
@@ -9,6 +9,15 @@ inputs:
   server:
     description: The provisioning server whose API will be queried.
     required: true
+  azure-token-url:
+    description: The Azure AD token URL for authentication with the provisioner.
+    required: true
+  azure-client-id:
+    description: The Azure AD client ID for authentication with the provisioner.
+    required: true
+  azure-client-secret:
+    description: The Azure AD client secret for authentication with the provisioner.
+    required: true
   username:
     description: The installation system admin username
     required: true
@@ -109,6 +118,9 @@ runs:
     - name: create-cloud-installation
       id: installation
       env:
+        AZURE_TOKEN_URL: ${{ inputs.azure-token-url }}
+        AZURE_CLIENT_ID: ${{ inputs.azure-client-id }}
+        AZURE_CLIENT_SECRET: ${{ inputs.azure-client-secret }}
         PROVISIONER_SERVER: ${{ inputs.server }}
         PROVISIONER_HEADERS: ${{ inputs.headers }}
         INSTALLATION_DNS: ${{ inputs.name }}.test.mattermost.cloud
@@ -131,6 +143,9 @@ runs:
     - name: wait-for-installation-readiness
       id: cluster-installation
       env:
+        AZURE_TOKEN_URL: ${{ inputs.azure-token-url }}
+        AZURE_CLIENT_ID: ${{ inputs.azure-client-id }}
+        AZURE_CLIENT_SECRET: ${{ inputs.azure-client-secret }}
         PROVISIONER_SERVER: ${{ inputs.server }}
         PROVISIONER_HEADERS: ${{ inputs.headers }}
         INSTALLATION_ID: ${{ steps.installation.outputs.id }}
@@ -141,6 +156,9 @@ runs:
     - name: initiate-installation
       id: state
       env:
+        AZURE_TOKEN_URL: ${{ inputs.azure-token-url }}
+        AZURE_CLIENT_ID: ${{ inputs.azure-client-id }}
+        AZURE_CLIENT_SECRET: ${{ inputs.azure-client-secret }}
         PROVISIONER_SERVER: ${{ inputs.server }}
         PROVISIONER_HEADERS: ${{ inputs.headers }}
         CLUSTER_INSTALLATION_ID: ${{ steps.cluster-installation.outputs.id }}

--- a/delivery/create-cloud-installation/action.yaml
+++ b/delivery/create-cloud-installation/action.yaml
@@ -9,14 +9,14 @@ inputs:
   server:
     description: The provisioning server whose API will be queried.
     required: true
-  azure-token-url:
-    description: The Azure AD token URL for authentication with the provisioner.
+  provisioner-token-url:
+    description: The token URL for authentication with the provisioner.
     required: true
-  azure-client-id:
-    description: The Azure AD client ID for authentication with the provisioner.
+  provisioner-client-id:
+    description: The client ID for authentication with the provisioner.
     required: true
-  azure-client-secret:
-    description: The Azure AD client secret for authentication with the provisioner.
+  provisioner-client-secret:
+    description: The client secret for authentication with the provisioner.
     required: true
   username:
     description: The installation system admin username
@@ -118,9 +118,9 @@ runs:
     - name: create-cloud-installation
       id: installation
       env:
-        AZURE_TOKEN_URL: ${{ inputs.azure-token-url }}
-        AZURE_CLIENT_ID: ${{ inputs.azure-client-id }}
-        AZURE_CLIENT_SECRET: ${{ inputs.azure-client-secret }}
+        PROVISIONER_TOKEN_URL: ${{ inputs.provisioner-token-url }}
+        PROVISIONER_CLIENT_ID: ${{ inputs.provisioner-client-id }}
+        PROVISIONER_CLIENT_SECRET: ${{ inputs.provisioner-client-secret }}
         PROVISIONER_SERVER: ${{ inputs.server }}
         PROVISIONER_HEADERS: ${{ inputs.headers }}
         INSTALLATION_DNS: ${{ inputs.name }}.test.mattermost.cloud
@@ -143,9 +143,9 @@ runs:
     - name: wait-for-installation-readiness
       id: cluster-installation
       env:
-        AZURE_TOKEN_URL: ${{ inputs.azure-token-url }}
-        AZURE_CLIENT_ID: ${{ inputs.azure-client-id }}
-        AZURE_CLIENT_SECRET: ${{ inputs.azure-client-secret }}
+        PROVISIONER_TOKEN_URL: ${{ inputs.provisioner-token-url }}
+        PROVISIONER_CLIENT_ID: ${{ inputs.provisioner-client-id }}
+        PROVISIONER_CLIENT_SECRET: ${{ inputs.provisioner-client-secret }}
         PROVISIONER_SERVER: ${{ inputs.server }}
         PROVISIONER_HEADERS: ${{ inputs.headers }}
         INSTALLATION_ID: ${{ steps.installation.outputs.id }}
@@ -156,9 +156,9 @@ runs:
     - name: initiate-installation
       id: state
       env:
-        AZURE_TOKEN_URL: ${{ inputs.azure-token-url }}
-        AZURE_CLIENT_ID: ${{ inputs.azure-client-id }}
-        AZURE_CLIENT_SECRET: ${{ inputs.azure-client-secret }}
+        PROVISIONER_TOKEN_URL: ${{ inputs.provisioner-token-url }}
+        PROVISIONER_CLIENT_ID: ${{ inputs.provisioner-client-id }}
+        PROVISIONER_CLIENT_SECRET: ${{ inputs.provisioner-client-secret }}
         PROVISIONER_SERVER: ${{ inputs.server }}
         PROVISIONER_HEADERS: ${{ inputs.headers }}
         CLUSTER_INSTALLATION_ID: ${{ steps.cluster-installation.outputs.id }}

--- a/delivery/create-cloud-installation/cloud.sh
+++ b/delivery/create-cloud-installation/cloud.sh
@@ -6,9 +6,26 @@ set -o pipefail
 
 source ${GITHUB_ACTION_PATH}/log.sh
 
+INFO "Fetching Azure AD token..."
+TOKEN_RESPONSE=$(curl --silent --location "${AZURE_TOKEN_URL}" \
+  --header 'Content-Type: application/x-www-form-urlencoded' \
+  --data-urlencode 'grant_type=client_credentials' \
+  --data-urlencode "client_id=${AZURE_CLIENT_ID}" \
+  --data-urlencode "client_secret=${AZURE_CLIENT_SECRET}" \
+  --data-urlencode 'scope=offline_access api://provisioner/.default')
+
+TOKEN=$(echo "${TOKEN_RESPONSE}" | jq --raw-output .access_token)
+if [ -z "${TOKEN}" ] || [ "${TOKEN}" == "null" ]; then
+  ERROR "Failed to retrieve Azure AD token"
+  ERROR "Response: ${TOKEN_RESPONSE}"
+  exit 1
+fi
+INFO "Successfully retrieved Azure AD token"
+
 INFO Constructing cloud command ...
 CMD=("cloud installation create")
 CMD_ARGS=("--server \"${PROVISIONER_SERVER}\"")
+CMD_ARGS+=("--header \"Authorization=Bearer ${TOKEN}\"")
 
 if [ -n "${PROVISIONER_HEADERS}" ]; then
   while IFS= read -r header; do

--- a/delivery/create-cloud-installation/cloud.sh
+++ b/delivery/create-cloud-installation/cloud.sh
@@ -6,21 +6,21 @@ set -o pipefail
 
 source ${GITHUB_ACTION_PATH}/log.sh
 
-INFO "Fetching Azure AD token..."
-TOKEN_RESPONSE=$(curl --silent --location "${AZURE_TOKEN_URL}" \
+INFO "Fetching provisioner token..."
+TOKEN_RESPONSE=$(curl --silent --location "${PROVISIONER_TOKEN_URL}" \
   --header 'Content-Type: application/x-www-form-urlencoded' \
   --data-urlencode 'grant_type=client_credentials' \
-  --data-urlencode "client_id=${AZURE_CLIENT_ID}" \
-  --data-urlencode "client_secret=${AZURE_CLIENT_SECRET}" \
+  --data-urlencode "client_id=${PROVISIONER_CLIENT_ID}" \
+  --data-urlencode "client_secret=${PROVISIONER_CLIENT_SECRET}" \
   --data-urlencode 'scope=offline_access api://provisioner/.default')
 
 TOKEN=$(echo "${TOKEN_RESPONSE}" | jq --raw-output .access_token)
 if [ -z "${TOKEN}" ] || [ "${TOKEN}" == "null" ]; then
-  ERROR "Failed to retrieve Azure AD token"
+  ERROR "Failed to retrieve provisioner token"
   ERROR "Response: ${TOKEN_RESPONSE}"
   exit 1
 fi
-INFO "Successfully retrieved Azure AD token"
+INFO "Successfully retrieved provisioner token"
 
 INFO Constructing cloud command ...
 CMD=("cloud installation create")

--- a/delivery/create-cloud-installation/ensure.sh
+++ b/delivery/create-cloud-installation/ensure.sh
@@ -6,6 +6,22 @@ set -o pipefail
 
 source ${GITHUB_ACTION_PATH}/log.sh
 
+INFO "Fetching Azure AD token..."
+TOKEN_RESPONSE=$(curl --silent --location "${AZURE_TOKEN_URL}" \
+  --header 'Content-Type: application/x-www-form-urlencoded' \
+  --data-urlencode 'grant_type=client_credentials' \
+  --data-urlencode "client_id=${AZURE_CLIENT_ID}" \
+  --data-urlencode "client_secret=${AZURE_CLIENT_SECRET}" \
+  --data-urlencode 'scope=offline_access api://provisioner/.default')
+
+TOKEN=$(echo "${TOKEN_RESPONSE}" | jq --raw-output .access_token)
+if [ -z "${TOKEN}" ] || [ "${TOKEN}" == "null" ]; then
+  ERROR "Failed to retrieve Azure AD token"
+  ERROR "Response: ${TOKEN_RESPONSE}"
+  exit 1
+fi
+INFO "Successfully retrieved Azure AD token"
+
 DESIRED_STATE="stable" 
 BACKOFF_SECONDS=10
 TIMEOUT_SECONDS=300
@@ -14,6 +30,7 @@ INFO Constructing cloud command ...
 
 CMD=("cloud installation get")
 CMD_ARGS=("--server \"${PROVISIONER_SERVER}\"")
+CMD_ARGS+=("--header \"Authorization=Bearer ${TOKEN}\"")
 
 if [ -n "${PROVISIONER_HEADERS}" ]; then
   while IFS= read -r header; do
@@ -59,6 +76,7 @@ OK "Cloud installation ${INSTALLATION_ID} is ready"
 INFO "Generating Outputs"
 CMD=("cloud cluster installation list")
 CMD_ARGS=("--server ${PROVISIONER_SERVER}")
+CMD_ARGS+=("--header \"Authorization=Bearer ${TOKEN}\"")
 
 if [ -n "${PROVISIONER_HEADERS}" ]; then
   while IFS= read -r header; do

--- a/delivery/create-cloud-installation/ensure.sh
+++ b/delivery/create-cloud-installation/ensure.sh
@@ -6,21 +6,21 @@ set -o pipefail
 
 source ${GITHUB_ACTION_PATH}/log.sh
 
-INFO "Fetching Azure AD token..."
-TOKEN_RESPONSE=$(curl --silent --location "${AZURE_TOKEN_URL}" \
+INFO "Fetching provisioner token..."
+TOKEN_RESPONSE=$(curl --silent --location "${PROVISIONER_TOKEN_URL}" \
   --header 'Content-Type: application/x-www-form-urlencoded' \
   --data-urlencode 'grant_type=client_credentials' \
-  --data-urlencode "client_id=${AZURE_CLIENT_ID}" \
-  --data-urlencode "client_secret=${AZURE_CLIENT_SECRET}" \
+  --data-urlencode "client_id=${PROVISIONER_CLIENT_ID}" \
+  --data-urlencode "client_secret=${PROVISIONER_CLIENT_SECRET}" \
   --data-urlencode 'scope=offline_access api://provisioner/.default')
 
 TOKEN=$(echo "${TOKEN_RESPONSE}" | jq --raw-output .access_token)
 if [ -z "${TOKEN}" ] || [ "${TOKEN}" == "null" ]; then
-  ERROR "Failed to retrieve Azure AD token"
+  ERROR "Failed to retrieve provisioner token"
   ERROR "Response: ${TOKEN_RESPONSE}"
   exit 1
 fi
-INFO "Successfully retrieved Azure AD token"
+INFO "Successfully retrieved provisioner token"
 
 DESIRED_STATE="stable" 
 BACKOFF_SECONDS=10

--- a/delivery/create-cloud-installation/init.sh
+++ b/delivery/create-cloud-installation/init.sh
@@ -6,21 +6,21 @@ set -o pipefail
 
 source ${GITHUB_ACTION_PATH}/log.sh
 
-INFO "Fetching Azure AD token..."
-TOKEN_RESPONSE=$(curl --silent --location "${AZURE_TOKEN_URL}" \
+INFO "Fetching provisioner token..."
+TOKEN_RESPONSE=$(curl --silent --location "${PROVISIONER_TOKEN_URL}" \
   --header 'Content-Type: application/x-www-form-urlencoded' \
   --data-urlencode 'grant_type=client_credentials' \
-  --data-urlencode "client_id=${AZURE_CLIENT_ID}" \
-  --data-urlencode "client_secret=${AZURE_CLIENT_SECRET}" \
+  --data-urlencode "client_id=${PROVISIONER_CLIENT_ID}" \
+  --data-urlencode "client_secret=${PROVISIONER_CLIENT_SECRET}" \
   --data-urlencode 'scope=offline_access api://provisioner/.default')
 
 TOKEN=$(echo "${TOKEN_RESPONSE}" | jq --raw-output .access_token)
 if [ -z "${TOKEN}" ] || [ "${TOKEN}" == "null" ]; then
-  ERROR "Failed to retrieve Azure AD token"
+  ERROR "Failed to retrieve provisioner token"
   ERROR "Response: ${TOKEN_RESPONSE}"
   exit 1
 fi
-INFO "Successfully retrieved Azure AD token"
+INFO "Successfully retrieved provisioner token"
 
 INFO Constructing cloud commands ...
 CMD=("cloud cluster installation mmctl")


### PR DESCRIPTION
#### Summary
This pull request adds Azure Active Directory (AD) authentication support to the cloud installation workflow. It introduces new inputs for Azure credentials, updates environment variables in the action configuration, and modifies shell scripts to fetch and use an Azure AD token for secure API requests to the provisioner.

**Azure AD Authentication Integration:**

* Added new required inputs (`azure-token-url`, `azure-client-id`, `azure-client-secret`) to `action.yaml` for Azure AD authentication.
* Updated environment variables in all relevant steps (`create-cloud-installation`, `wait-for-installation-readiness`, `initiate-installation`) within `action.yaml` to pass Azure AD credentials to shell scripts.


#### Ticket Link
https://mattermost.atlassian.net/browse/SEC-9172
