### PR TITLE
Fixing flakiness with release note generation for plugin releases

### DIFF
--- a/plugin-ci/build/action.yaml
+++ b/plugin-ci/build/action.yaml
@@ -15,12 +15,34 @@ runs:
     - name: generate-release-notes
       shell: bash
       run: |
-        printf "Supported Mattermost Server Versions: **$(cat plugin.json | jq .min_server_version -r)+** \n## Enhancements\n\n## Fixes\n"  >> dist/release-notes.md
-        if [[ $(git tag -l | wc -l) -eq 1 ]]; then
-          git log --pretty='format:- %h %s' --abbrev-commit --no-decorate --no-color $(git rev-list --max-parents=0 HEAD) HEAD >> dist/release-notes.md
+        printf "Supported Mattermost Server Versions: **$(cat plugin.json | jq .min_server_version -r)+** \n## Enhancements\n\n## Fixes\n" >> dist/release-notes.md
+        CURRENT_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+
+        if [[ -z $CURRENT_TAG ]]; then
+          # No tags exist —> include the entire commit history
+          RANGE="$(git rev-list --max-parents=0 HEAD) HEAD"
+        elif [[ $CURRENT_TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          FULL_RELEASE_COUNT=$(git tag -l 'v*' | grep -cE '^v[0-9]+\.[0-9]+\.[0-9]+$')
+          if [[ $FULL_RELEASE_COUNT -le 1 ]]; then
+            # First-ever full release —> include the entire commit history
+            RANGE="$(git rev-list --max-parents=0 HEAD) HEAD"
+          else
+            # More than one full release exists —> range spans back to the previous full release
+            PREV_FULL_RELEASE=$(git tag -l 'v*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V -r | sed -n '2p')
+            RANGE="${PREV_FULL_RELEASE}..HEAD"
+          fi
         else
-          git log --pretty='format:- %h %s' --abbrev-commit --no-decorate --no-color $(git describe --tags --abbrev=0 $(git describe --tags --abbrev=0)^)..HEAD >> dist/release-notes.md
+          # Pre-release tag (e.g. v1.2.3-rc1) — range spans only to the immediately
+          # previous tag, so each RC shows just its incremental changes
+          if [[ $(git tag -l | wc -l) -eq 1 ]]; then
+            # Only one tag exists —> include the entire commit history
+            RANGE="$(git rev-list --max-parents=0 HEAD) HEAD"
+          else
+            PREV_TAG=$(git describe --tags --abbrev=0 ${CURRENT_TAG}^)
+            RANGE="${PREV_TAG}..HEAD"
+          fi
         fi
+        git log --pretty='format:- %h %s' --abbrev-commit --no-decorate --no-color ${RANGE} >> dist/release-notes.md
 
     - name: upload-plugin-package
       uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0


### PR DESCRIPTION

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
This PR ensures better accuracy in the range of commits included in the release notes depending on whether it's an RC or full release.

Until now if we had multiple subsequent RC tags created (e.g. `v1.2.3-rc1`, `v1.2.3-rc2`, ...), the release note for the full release would only include the contents of the last generated RC release note, which then require manual copy-pasting of the contents of all RC release notes to compose the complete list of fixes.

This should make sure that we keep the RC behavior of only including fixes for the same RC version, but full releases aggregate changes since the last full release

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://mattermost.atlassian.net/browse/MM-67849