### PR TITLE
Add plugin-ci/build-fips composite for FIPS plugin builds

### DIFF
--- a/plugin-ci/build-fips/action.yaml
+++ b/plugin-ci/build-fips/action.yaml
@@ -1,0 +1,34 @@
+# Copyright 2026 Mattermost, Inc.
+name: "plugin-ci/build-fips"
+description: |
+  Build and verify the FIPS Linux/amd64 variant of a Mattermost plugin.
+
+  Requires:
+  - The plugin opts in by shipping `build/fips.mk` (see PR 1 in the FIPS
+    automation rollout).
+  - The calling job grants `id-token: write` permissions so setup-chainctl
+    can authenticate to cgr.dev via OIDC.
+
+  The caller is responsible for uploading `dist-fips/*.tar.gz` as an
+  artifact — artifact shape decisions live at the workflow level.
+
+inputs:
+  chainguard-identity:
+    description: "Chainguard identity ID to authenticate against cgr.dev."
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: chainctl/auth
+      uses: chainguard-dev/setup-chainctl@67a753db49c7e97fed4c76fbe809b1339b11facf
+      with:
+        identity: ${{ inputs.chainguard-identity }}
+
+    - name: build-fips
+      shell: bash
+      run: make dist-fips
+
+    - name: verify-fips
+      shell: bash
+      run: make verify-fips


### PR DESCRIPTION
#### Summary

Adds a new shared composite action, `plugin-ci/build-fips`, that authenticates to `cgr.dev` via `setup-chainctl` OIDC and runs `make dist-fips` + `make verify-fips`. Intended to be opted into by plugin CI workflows (and by the tagged-release pipeline in `delivery-platform`) to produce a verified FIPS Linux/amd64 plugin bundle alongside the normal bundle.

Build-and-verify only — the caller drives uploads, so artifact shape decisions (combined vs. split, names, retention) stay at the workflow level.

The composite has no caller yet; the consumers will land in follow-up PRs on `mattermost-plugin-agents` and `delivery-platform`. No behaviour change to existing pipelines.

Pinned `chainguard-dev/setup-chainctl` to the same SHA used by `release-mattermost-platform.yml` and `mattermost-platform-docker-dev.yml` for consistency with the rest of the FIPS path.

#### Ticket Link

N/A